### PR TITLE
去除重复功能，硬编码提升效率

### DIFF
--- a/RIP-hltv-BET.user.js
+++ b/RIP-hltv-BET.user.js
@@ -2,7 +2,7 @@
 // @name                RIP HLTV BET
 // @name:zh-CN          HLTV 广告去除插件
 // @namespace           https://github.com/wolfcon/RIP-HLTV-BET
-// @version             1.2
+// @version             1.3
 // @description         Remove hltv.org Annoy AD
 // @description:zh-cn   清除那些🤮背景赌博广告.
 // @author              Frank
@@ -13,53 +13,27 @@
 // @run-at              document-body
 // ==/UserScript==
 
-const filters = '[class*="yabo"], [href*="bet"], a:not([href^="/"])';
-// Use ADBlock way to block some annoy element
-function removeFilters() {
+(function() {
+    const filters = [
+        '[class*="yabo"]',
+        '[class*="kgN8P9bvyb2EqDJR"]',
+        '[class*="ASdvuasdr123Gazx"]',
+        '[class*="regional"]',
+        '[class*="world"]',
+        '[class*="bet"]',
+        '[href*="/betting/analytics"]',
+        '[href*="/fantasy"]',
+        '[href*="lzhtys"]',
+        '[href*="http://manilasunyanzi.cn"]',
+        //'a:not([href^="/"])'
+    ];
+
+    // Use ADBlock way to block some annoy element
     var $hiddenStyle = $('<style type="text/css"></style>');
     $($('head')[0]).append($hiddenStyle);
     $hiddenStyle.append(filters + "{display: none !important; visibility: hidden !important;}");
-}
-
-function removeAll() {
-    'use strict';
-
-    function removeNonOfficialSiteElement(element) {
-        const adA = $(element).find('a').not('[href^="/"]');
-        $(adA).remove();
-    }
-
-    function removeClassElement(filter) {
-        const ele = $('div,aside').find(filter);
-        $(ele).remove();
-    }
 
     // removeBackgroundAd
     document.body.removeAttribute("data-href");
     document.body.removeAttribute("style");
-
-    (function removeTopAds() {
-        var topDiv = document.getElementsByClassName("logoCon")[0];
-        var adCount = topDiv.children.length - 1;
-
-        while (adCount > 0) {
-            topDiv.removeChild(topDiv.lastElementChild);
-            adCount--;
-        }
-    })();
-
-    // removeLeftColumnAd
-    removeNonOfficialSiteElement($('.leftCol'));
-
-    // removeRightColumnAd
-    removeNonOfficialSiteElement($('.rightCol'));
-    removeNonOfficialSiteElement($('.right2Col'));
-
-    // removeContentColumnAd
-    removeNonOfficialSiteElement($('.contentCol'));
-
-    // remove extra filters
-    removeFilters();
-};
-
-removeAll();
+})();


### PR DESCRIPTION
filters 中添加 '[class*="kgN8P9bvyb2EqDJR"]' 代替  removeTopAds() 的循环以提升效率
filters 中添加 ‘[class*="regional"]', '[class*="world"]', 去除单次比赛详情页的菠菜表格

去除与 filters 中 ‘a:not([href^="/"])’ 重复的 removeNonOfficialSiteElement(element)
去除旧代码残余 removeClassElement(filter)

因  ‘a:not([href^="/"])’  对 match 界面 Featured News 的误伤，在 filters 中添加其他硬编码