### PR TITLE
Fix remove betting sections not work issues.

### DIFF
--- a/RIP-hltv-BET.user.js
+++ b/RIP-hltv-BET.user.js
@@ -38,6 +38,10 @@ const filters = [
 document.body.removeAttribute("data-href");
 document.body.removeAttribute("style");
 
+const hiddenStyle = document.createElement("style")
+hiddenStyle.innerText = "#betting {display: none}"
+document.head.appendChild(hiddenStyle)
+
 // set background to bar Color
 $(document.body).css("background-color", $(".navbar").css("background-color"));
 
@@ -51,20 +55,3 @@ $(document.body).css("background-color", $(".navbar").css("background-color"));
         adCount--;
     }
 })();
-
-function removeBettingTableInMatchDetail() {
-    setTimeout(function () {
-        var bettingDiv = document.getElementById("betting");
-        if (bettingDiv == null) return;
-        bettingDiv.removeChild(bettingDiv.firstElementChild);
-    }, 50);
-};
-
-while (1) {
-    let bettingDiv = document.getElementById("betting");
-    if (bettingDiv) {
-        console.log("remove betting")
-        removeBettingTableInMatchDetail()
-        break
-    }
-}

--- a/RIP-hltv-BET.user.js
+++ b/RIP-hltv-BET.user.js
@@ -52,10 +52,19 @@ $(document.body).css("background-color", $(".navbar").css("background-color"));
     }
 })();
 
-(function removeBettingTableInMatchDetail() {
-    setTimeout(function() {
+function removeBettingTableInMatchDetail() {
+    setTimeout(function () {
         var bettingDiv = document.getElementById("betting");
         if (bettingDiv == null) return;
         bettingDiv.removeChild(bettingDiv.firstElementChild);
     }, 50);
-})();
+};
+
+while (1) {
+    let bettingDiv = document.getElementById("betting");
+    if (bettingDiv) {
+        console.log("remove betting")
+        removeBettingTableInMatchDetail()
+        break
+    }
+}


### PR DESCRIPTION
修复了页面中详细数据下方的赌博列表界面依然会显示的问题。将之前的使用删除div来隐藏的方法改为在head中加入隐藏指定id的元素的方法。